### PR TITLE
Reduce warnings

### DIFF
--- a/buzzard/_a_source_vector.py
+++ b/buzzard/_a_source_vector.py
@@ -1,5 +1,6 @@
 import collections
 import sys
+from collections.abc import Container
 
 import shapely.geometry as sg
 import numpy as np
@@ -261,7 +262,7 @@ class ASourceVector(ASource):
             return mask, None
         elif isinstance(mask, Footprint):
             return mask.poly, None
-        elif isinstance(mask, collections.Container):
+        elif isinstance(mask, Container):
             mask = [float(v) for v in mask]
             minx, maxx, miny, maxy = mask
             mask = minx, miny, maxx, maxy

--- a/buzzard/_a_stored_vector.py
+++ b/buzzard/_a_stored_vector.py
@@ -1,4 +1,4 @@
-import collections
+from collections.abc import Iterable, Mapping
 
 import shapely.geometry as sg
 
@@ -57,7 +57,7 @@ class AStoredVector(AStored, ASourceVector):
                 )
         elif isinstance(geom, sg.base.BaseGeometry):
             geom_type = 'shapely'
-        elif isinstance(geom, collections.Iterable):
+        elif isinstance(geom, Iterable):
             geom_type = 'coordinates'
         else:
             raise TypeError('input `geom` should be a shapely geometry or nest coordinates')
@@ -66,7 +66,7 @@ class AStoredVector(AStored, ASourceVector):
 
     def _normalize_field_values(self, fields):
         """Used on feature insertion"""
-        if isinstance(fields, collections.Mapping):
+        if isinstance(fields, Mapping):
             lst = [None] * len(self._back.fields)
             for k, v in fields.items():
                 if v is None:
@@ -78,7 +78,7 @@ class AStoredVector(AStored, ASourceVector):
                 if val is None and defn['nullable'] is False: # pragma: no cover
                     raise ValueError('{} not nullable'.format(defn))
             return lst
-        elif isinstance(fields, collections.Iterable):
+        elif isinstance(fields, Iterable):
             if len(fields) == 0 and self._back.all_nullable:
                 return [None] * len(self._back.fields)
             elif len(fields) != len(self._back.fields): # pragma: no cover

--- a/buzzard/_tools/conv/_gdal_conv.py
+++ b/buzzard/_tools/conv/_gdal_conv.py
@@ -6,7 +6,7 @@ http://www.gdal.org/ogr__core_8h.html
 
 import datetime
 import json
-import collections
+from collections.abc import Iterable
 
 import shapely.wkt as sw
 from osgeo import ogr, gdal
@@ -46,7 +46,7 @@ def ogr_of_coordinates(geom, type_):
     def _to_list(obj):
         if isinstance(obj, np.ndarray):
             return obj.tolist()
-        elif isinstance(obj, collections.Iterable):
+        elif isinstance(obj, Iterable):
             return [_to_list(elt) for elt in obj]
         else:
             return obj

--- a/buzzard/_tools/conv/_gdal_gdt_conv.py
+++ b/buzzard/_tools/conv/_gdal_gdt_conv.py
@@ -6,7 +6,7 @@ All types are not available on all platforms, hence the `_eval_filter_dict_key({
 from osgeo import gdal
 import numpy as np
 
-DTYPE_OF_NAME = {np.dtype(v).name: np.dtype(v) for v in np.typeDict.values()}
+DTYPE_OF_NAME = {np.dtype(v).name: np.dtype(v) for v in np.sctypeDict.values()}
 
 def _eval_filter_dict_key(d):
     return {

--- a/buzzard/_tools/parameters.py
+++ b/buzzard/_tools/parameters.py
@@ -1,9 +1,8 @@
 """Private tools to normalize functions parameters"""
 
-import collections
+from collections.abc import Iterable
 import logging
 import functools
-import numbers
 
 import six
 import numpy as np
@@ -37,7 +36,7 @@ def _coro_parameter_0or1dim(val, clean_fn, name):
         yield True
         yield attempt
         return
-    if isinstance(val, str) or not isinstance(val, collections.Iterable): # pragma: no cover
+    if isinstance(val, str) or not isinstance(val, Iterable): # pragma: no cover
         raise TypeError(
             'Expecting a `{}` or an `sequence of `{}`, found a `{}`'.format(name, name, type(val))
         )
@@ -363,7 +362,7 @@ deprecation_pool = _DeprecationPool()
 
 def normalize_fields_defn(fields):
     """Used on file creation"""
-    if not isinstance(fields, collections.Iterable): # pragma: no cover
+    if not isinstance(fields, Iterable): # pragma: no cover
         raise TypeError('Bad fields definition type')
 
     def _sanitize_dict(dic):

--- a/buzzard/test/test_vectorsource_getsetdata_general.py
+++ b/buzzard/test/test_vectorsource_getsetdata_general.py
@@ -1,8 +1,8 @@
 # pylint: disable=redefined-outer-name
 
 from __future__ import division, print_function
+from collections.abc import Container
 import logging
-import collections
 import itertools
 import tempfile
 import os
@@ -347,7 +347,7 @@ def _any_geom_to_shapely(geom):
         return geom
     if isinstance(geom, dict):
         return sg.shape(geom['geometry'])
-    if isinstance(geom, collections.Container):
+    if isinstance(geom, Container):
         geom = np.asarray(geom)
         if geom.ndim == 1:
             return sg.Point(geom.tolist())


### PR DESCRIPTION
- Import `Mapping`, `Iterable` and `Container` from collections.abc. This was deprecated since Python 3.3
- Use `np.sctypeDict` instead of `np.typeDict`. The latter was a deprecated alias of the former and has been since 2006.