### PR TITLE
Use Python3.6+ syntax

### DIFF
--- a/buzzard/_a_async_raster.py
+++ b/buzzard/_a_async_raster.py
@@ -67,7 +67,7 @@ class AAsyncRaster(ASourceRaster):
         """
         for fp in fps:
             if not isinstance(fp, Footprint):
-                msg = 'element of `fps` parameter should be a Footprint (not {})'.format(fp) # pragma: no cover
+                msg = f'element of `fps` parameter should be a Footprint (not {fp})' # pragma: no cover
                 raise ValueError(msg)
 
         return self._back.queue_data(
@@ -145,7 +145,7 @@ class ABackAsyncRaster(ABackSourceRaster):
                    parent_uid, key_in_parent):
         q = queue.Queue(max_queue_size)
         self.back_ds.put_message(Msg(
-            '/Raster{}/QueriesHandler'.format(self.uid),
+            f'/Raster{self.uid}/QueriesHandler',
             'new_query',
             weakref.ref(q),
             max_queue_size,

--- a/buzzard/_a_emissary.py
+++ b/buzzard/_a_emissary.py
@@ -62,7 +62,7 @@ class ABackEmissary(ABackStored):
         self.driver = driver
         self.open_options = open_options
         self.path = path
-        super(ABackEmissary, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
 
     def delete(self):

--- a/buzzard/_a_emissary_vector.py
+++ b/buzzard/_a_emissary_vector.py
@@ -17,5 +17,5 @@ class ABackEmissaryVector(ABackEmissary, ABackStoredVector):
     """Implementation of AEmissaryVector's specifications"""
 
     def __init__(self, layer, **kwargs):
-        super(ABackEmissaryVector, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.layer = layer

--- a/buzzard/_a_gdal_raster.py
+++ b/buzzard/_a_gdal_raster.py
@@ -37,8 +37,8 @@ class ABackGDALRaster(ABackStoredRaster):
 
     def sample_bands_driver(self, fp, channel_ids, gdal_ds):
         rtlx, rtly = self.fp.spatial_to_raster(fp.tl)
-        assert rtlx >= 0 and rtlx < self.fp.rsizex, '{} >= 0 and {} < {}'.format(rtlx, rtlx, self.fp.rsizex)
-        assert rtly >= 0 and rtly < self.fp.rsizey, '{} >= 0 and {} < {}'.format(rtly, rtly, self.fp.rsizey)
+        assert rtlx >= 0 and rtlx < self.fp.rsizex, f'{rtlx} >= 0 and {rtlx} < {self.fp.rsizex}'
+        assert rtly >= 0 and rtly < self.fp.rsizey, f'{rtly} >= 0 and {rtly} < {self.fp.rsizey}'
 
         dstarray = np.empty(np.r_[fp.shape, len(channel_ids)], self.dtype)
         for i, channel_id in enumerate(channel_ids):

--- a/buzzard/_a_gdal_vector.py
+++ b/buzzard/_a_gdal_vector.py
@@ -111,14 +111,14 @@ class ABackGDALVector(ABackStoredVector):
                 for i in indices:
                     ftr = lyr.GetNextFeature()
                     if ftr is None: # pragma: no cover
-                        raise IndexError('Feature #{} not found'.format(i))
+                        raise IndexError(f'Feature #{i} not found')
                     yield ftr
             else:
                 for i in indices:
                     lyr.SetNextByIndex(i)
                     ftr = lyr.GetNextFeature()
                     if ftr is None: # pragma: no cover
-                        raise IndexError('Feature #{} not found'.format(i))
+                        raise IndexError(f'Feature #{i} not found')
                     yield ftr
 
         # Necessary to prevent the old swig bug

--- a/buzzard/_a_pooled_emissary.py
+++ b/buzzard/_a_pooled_emissary.py
@@ -40,7 +40,7 @@ class ABackPooledEmissary(ABackEmissary):
 
     def __init__(self, uid, **kwargs):
         self.uid = uid
-        super(ABackPooledEmissary, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def activate(self):
         self.back_ds.activate(self.uid, self.allocator)
@@ -62,7 +62,7 @@ class ABackPooledEmissary(ABackEmissary):
         - Should always be called
         """
         self.back_ds.deactivate(self.uid)
-        super(ABackPooledEmissary, self).close()
+        super().close()
 
     def delete(self):
         """Virtual method:
@@ -73,4 +73,4 @@ class ABackPooledEmissary(ABackEmissary):
         Ideally a `close` should be performed before a delete.
         """
         self.back_ds.deactivate(self.uid)
-        super(ABackPooledEmissary, self).delete()
+        super().delete()

--- a/buzzard/_a_source.py
+++ b/buzzard/_a_source.py
@@ -4,7 +4,7 @@ from osgeo import osr
 
 from buzzard import _tools
 
-class ASource(object):
+class ASource:
     """Base abstract class defining the common behavior of all sources opened in the Dataset.
 
     Features Defined
@@ -93,7 +93,7 @@ class ASource(object):
         '0.4.4'
     )
 
-class ABackSource(object):
+class ABackSource:
     """Implementation of ASource's specifications"""
 
     def __init__(self, back_ds, wkt_stored, rect, **kwargs):

--- a/buzzard/_a_source_raster.py
+++ b/buzzard/_a_source_raster.py
@@ -153,7 +153,7 @@ class ASourceRaster(ASource):
         if fp is None:
             fp = self.fp
         elif not isinstance(fp, Footprint): # pragma: no cover
-            raise ValueError('`fp` parameter should be a Footprint (not {})'.format(fp))
+            raise ValueError(f'`fp` parameter should be a Footprint (not {fp})')
 
         # Normalize and check channels parameter
         channel_ids, is_flat = _tools.normalize_channels_parameter(
@@ -202,7 +202,7 @@ class ABackSourceRaster(ABackSource, ABackSourceRasterRemapMixin):
     """Implementation of ASourceRaster's specifications"""
 
     def __init__(self, channels_schema, dtype, fp_stored, **kwargs):
-        super(ABackSourceRaster, self).__init__(rect=fp_stored, **kwargs)
+        super().__init__(rect=fp_stored, **kwargs)
 
         if self.to_work is not None:
             fp = fp_stored.move(*self.to_work([

--- a/buzzard/_a_source_raster_remap.py
+++ b/buzzard/_a_source_raster_remap.py
@@ -20,7 +20,7 @@ _EXN_FORMAT2 = """The `interpolation` parameter is None. It means that either
 2. or that you want to perform a resampling operation and that you need `interpolation` to be a string.
 """
 
-class ABackSourceRasterRemapMixin(object):
+class ABackSourceRasterRemapMixin:
     """Raster Mixin containing remap subroutine"""
 
     _REMAP_MASK_MODES = frozenset(['dilate', 'erode', ])
@@ -188,7 +188,7 @@ class ABackSourceRasterRemapMixin(object):
                            mask_mode, interpolation):
         if array is not None and array.dtype in [np.dtype('float64'), np.dtype('bool')]:
             raise ValueError(
-                'dtype {!r} not handled by cv2.remap'.format(array.dtype)
+                f'dtype {array.dtype!r} not handled by cv2.remap'
             ) # pragma: no cover
 
         mapx, mapy = dst_fp.meshgrid_raster_in(src_fp, dtype='float32')

--- a/buzzard/_a_source_vector.py
+++ b/buzzard/_a_source_vector.py
@@ -170,7 +170,7 @@ class ASourceVector(ASource):
         for val in self.iter_data(fields, geom_type, mask, clip, slice(index, index + 1, 1)):
             return val
         else: # pragma: no cover
-            raise IndexError('Feature `{}` not found'.format(index))
+            raise IndexError(f'Feature `{index}` not found')
 
     def iter_geojson(self, mask=None, clip=False, slicing=slice(0, None, 1)):
         """Create an iterator over vector's features
@@ -253,7 +253,7 @@ class ASourceVector(ASource):
         for val in self.iter_geojson(mask, clip, slice(index, index + 1, 1)):
             return val
         else: # pragma: no cover
-            raise IndexError('Feature `{}` not found'.format(index))
+            raise IndexError(f'Feature `{index}` not found')
 
     @staticmethod
     def _normalize_mask_parameter(mask):
@@ -281,7 +281,7 @@ class ABackSourceVector(ABackSource):
     """Implementation of ASourceVector's specifications"""
 
     def __init__(self, type, fields, **kwargs):
-        super(ABackSourceVector, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.type = type
         self.fields = fields
         self.index_of_field_name = {

--- a/buzzard/_a_stored.py
+++ b/buzzard/_a_stored.py
@@ -19,4 +19,4 @@ class ABackStored(ABackSource):
 
     def __init__(self, mode, **kwargs):
         self.mode = mode
-        super(ABackStored, self).__init__(**kwargs)
+        super().__init__(**kwargs)

--- a/buzzard/_a_stored_raster.py
+++ b/buzzard/_a_stored_raster.py
@@ -106,7 +106,7 @@ class AStoredRaster(AStored, ASourceRaster):
         if fp is None:
             fp = self.fp
         elif not isinstance(fp, Footprint):
-            raise ValueError('`fp` parameter should be a Footprint (not {})'.format(fp)) # pragma: no cover
+            raise ValueError(f'`fp` parameter should be a Footprint (not {fp})') # pragma: no cover
 
         # Normalize and check channels parameter
         channel_ids, _ = _tools.normalize_channels_parameter(channels, len(self))
@@ -117,7 +117,7 @@ class AStoredRaster(AStored, ASourceRaster):
         # Normalize and check array parameter
         array = np.atleast_3d(array)
         if array.ndim != 3: # pragma: no cover
-            raise ValueError('Input array should have 2 or 3 dimensions, not {}'.format(array.ndim))
+            raise ValueError(f'Input array should have 2 or 3 dimensions, not {array.ndim}')
         if array.shape[:2] != tuple(fp.shape): # pragma: no cover
             msg = 'Incompatible shape between input `array` ({}) and `fp` ({})'.format(
                 array.shape[:2], tuple(fp.shape)

--- a/buzzard/_a_stored_vector.py
+++ b/buzzard/_a_stored_vector.py
@@ -76,7 +76,7 @@ class AStoredVector(AStored, ASourceVector):
                     lst[i] = self._back.type_of_field_index[i](v)
             for defn, val in zip(self._back.fields, lst):
                 if val is None and defn['nullable'] is False: # pragma: no cover
-                    raise ValueError('{} not nullable'.format(defn))
+                    raise ValueError(f'{defn} not nullable')
             return lst
         elif isinstance(fields, collections.Iterable):
             if len(fields) == 0 and self._back.all_nullable:
@@ -97,7 +97,7 @@ class ABackStoredVector(ABackStored, ABackSourceVector):
     """Implementation of AStoredRaster's specifications"""
 
     def __init__(self, **kwargs):
-        super(ABackStoredVector, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def insert_data(self, geom, geom_type, fields, index): # pragma: no cover
         raise NotImplementedError('ABackStoredVector.insert_data is virtual pure')

--- a/buzzard/_dataset.py
+++ b/buzzard/_dataset.py
@@ -385,7 +385,7 @@ class Dataset(DatasetRegisterMixin):
             ds_id=id(self),
             debug_observers=debug_observers,
         )
-        super(Dataset, self).__init__()
+        super().__init__()
 
     # Raster entry points *********************************************************************** **
     def open_raster(self, key, path, driver='GTiff', options=(), mode='r'):
@@ -1385,7 +1385,7 @@ class Dataset(DatasetRegisterMixin):
 
     def create_vector(self, key, path, type, fields=(), layer=None,
                       driver='ESRI Shapefile', options=(), sr=None, ow=False):
-        """Create an empty vector file and register it under `key` within this Dataset. Only metadata
+        r"""Create an empty vector file and register it under `key` within this Dataset. Only metadata
         are kept in memory.
 
         >>> help(GDALFileVector)
@@ -1645,8 +1645,7 @@ class Dataset(DatasetRegisterMixin):
     def keys(self):
         """Generate all source keys"""
         for source, keys in self._keys_of_source.items():
-            for key in keys:
-                yield key
+            yield from keys
 
     def values(self):
         """Generate all proxies"""
@@ -1823,5 +1822,5 @@ _CloseRoutine = type('_CloseRoutine', (_tools.CallOrContext,), {
 
 DataSource = deprecation_pool.wrap_class(Dataset, 'DataSource', '0.6.0')
 
-class _AnonymousSentry(object):
+class _AnonymousSentry:
     """Sentry object used to instanciate anonymous proxies"""

--- a/buzzard/_dataset_back.py
+++ b/buzzard/_dataset_back.py
@@ -1,4 +1,3 @@
-
 from buzzard._dataset_back_conversions import BackDatasetConversionsMixin
 from buzzard._dataset_back_activation_pool import BackDatasetActivationPoolMixin
 from buzzard._dataset_back_scheduler import BackDatasetSchedulerMixin
@@ -14,4 +13,4 @@ class BackDataset(BackDatasetConversionsMixin,
         self.allow_interpolation = allow_interpolation
         self.allow_none_geometry = allow_none_geometry
         self.pools_container = PoolsContainer()
-        super(BackDataset, self).__init__(**kwargs)
+        super().__init__(**kwargs)

--- a/buzzard/_dataset_back_activation_pool.py
+++ b/buzzard/_dataset_back_activation_pool.py
@@ -7,7 +7,7 @@ from buzzard._tools import MultiOrderedDict
 _ERR_FMT = 'Dataset is configured for a maximum of {} simultaneous active driver objects \
 but there are already {} idle objects and {} used objects'
 
-class BackDatasetActivationPoolMixin(object):
+class BackDatasetActivationPoolMixin:
     """Private mixin for the Dataset class containing subroutines for proxies' driver
     objects pooling"""
 
@@ -16,7 +16,7 @@ class BackDatasetActivationPoolMixin(object):
         self._ap_lock = threading.Lock()
         self._ap_idle = MultiOrderedDict()
         self._ap_used = collections.Counter()
-        super(BackDatasetActivationPoolMixin, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def activate(self, uid, allocator):
         """Make sure at least one driver object is idle or used for uid"""

--- a/buzzard/_dataset_back_conversions.py
+++ b/buzzard/_dataset_back_conversions.py
@@ -4,7 +4,7 @@ from osgeo import osr
 from buzzard import srs
 from buzzard._footprint import Footprint
 
-class BackDatasetConversionsMixin(object):
+class BackDatasetConversionsMixin:
     """Private mixin for the Dataset class containing the spatial coordinates
     conversion subroutines"""
 
@@ -30,7 +30,7 @@ class BackDatasetConversionsMixin(object):
         self.sr_fallback = sr_fallback
         self.sr_forced = sr_forced
         self.analyse_transformations = analyse_transformation
-        super(BackDatasetConversionsMixin, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def get_transforms(self, sr_virtual, rect, rect_from='virtual'):
         """Retrieve the `to_work` and `to_virtual` conversion functions.

--- a/buzzard/_dataset_back_scheduler.py
+++ b/buzzard/_dataset_back_scheduler.py
@@ -9,7 +9,7 @@ from buzzard._debug_observers_manager import DebugObserversManager
 
 VERBOSE = 0
 
-class BackDatasetSchedulerMixin(object):
+class BackDatasetSchedulerMixin:
     """TODO: docstring"""
 
     def __init__(self, ds_id, debug_observers, **kwargs):
@@ -26,7 +26,7 @@ class BackDatasetSchedulerMixin(object):
         if self._thread is None:
             self._thread = threading.Thread(
                 target=self._exception_catcher,
-                name='Dataset{:#x}Scheduler'.format(self._ds_id),
+                name=f'Dataset{self._ds_id:#x}Scheduler',
                 daemon=True,
             )
             self._thread.start()
@@ -155,7 +155,7 @@ class BackDatasetSchedulerMixin(object):
                     for dst_actor in _find_actors(msg.address, src_actor):
                         if dst_actor is None:
                             # This message may be discadted if DroppableMsg
-                            assert isinstance(msg, DroppableMsg), '\ndst_actor: {}\n      msg: {}\n'.format(dst_actor, msg)
+                            assert isinstance(msg, DroppableMsg), f'\ndst_actor: {dst_actor}\n      msg: {msg}\n'
                         else:
                             a = datetime.datetime.now()
                             met = getattr(dst_actor, title_prefix + msg.title)

--- a/buzzard/_dataset_pools_container.py
+++ b/buzzard/_dataset_pools_container.py
@@ -3,7 +3,7 @@ import collections
 import multiprocessing as mp
 import multiprocessing.pool
 
-class PoolsContainer(object):
+class PoolsContainer:
     """Manages thread/process pools and aliases for a Dataset"""
 
     def __init__(self):

--- a/buzzard/_dataset_register.py
+++ b/buzzard/_dataset_register.py
@@ -1,19 +1,19 @@
 import threading
 
-class DatasetRegisterMixin(object):
+class DatasetRegisterMixin:
     """Private mixin for the Dataset class containing subroutines for proxies registration"""
 
     def __init__(self, **kwargs):
         self._keys_of_source = {}
         self._source_of_key = {}
         self._register_lock = threading.Lock()
-        super(DatasetRegisterMixin, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def _register(self, keys, prox):
         with self._register_lock:
             for key in keys:
                 if key in self.__dict__: # pragma: no cover
-                    raise ValueError('key `{}` is already bound'.format(key))
+                    raise ValueError(f'key `{key}` is already bound')
             self._keys_of_source[prox] = keys
             for key in keys:
                 self._source_of_key[key] = prox

--- a/buzzard/_debug_observers_manager.py
+++ b/buzzard/_debug_observers_manager.py
@@ -1,6 +1,6 @@
 import collections
 
-class DebugObserversManager(object):
+class DebugObserversManager:
     """Delivers the callbacks to the observers provided by user in the `debug_observers` parameters.
     """
     def __init__(self, debug_observers):
@@ -16,7 +16,7 @@ class _ToCallPerEventName(dict):
         self._obs = debug_observers
 
     def __missing__(self, ename):
-        method_name = 'on_{}'.format(ename)
+        method_name = f'on_{ename}'
         return [
             getattr(o, method_name)
             for o in self._obs

--- a/buzzard/_env.py
+++ b/buzzard/_env.py
@@ -84,7 +84,7 @@ class _Storage(threading.local):
 _LOCAL = _Storage()
 
 # Env update ************************************************************************************ **
-class Env(object):
+class Env:
     """Context manager to update buzzard's states. Can also be used as a decorator.
 
     Parameters
@@ -152,7 +152,7 @@ class Env(object):
         return f
 
 # Value retrieval ******************************************************************************* **
-class _ThreadMapStackGetter(object):
+class _ThreadMapStackGetter:
     """Getter for env attribute"""
     def __init__(self, key):
         self.key = key

--- a/buzzard/_footprint.py
+++ b/buzzard/_footprint.py
@@ -2,7 +2,6 @@
 
 # pylint: disable=too-many-lines
 
-from __future__ import division, print_function
 import logging
 import itertools
 
@@ -175,7 +174,7 @@ class Footprint(TileMixin, IntersectionMixin, MoveMixin):
         else:
             raise ValueError('Provide `size & gt` or `rsize & size & tl`')
         if kwargs:
-            raise ValueError('Unknown parameters [{}]'.format(kwargs.keys()))
+            raise ValueError(f'Unknown parameters [{kwargs.keys()}]')
 
         if a * e - d * b == 0:
             raise ValueError('Determinent should not be 0: {}'.format(
@@ -233,9 +232,9 @@ class Footprint(TileMixin, IntersectionMixin, MoveMixin):
         # Check extent parameter
         extent = np.asarray(extent, dtype='float64')
         if extent.shape != (4,):
-            raise ValueError('Invalid extent shape `{}`'.format(extent.shape))
+            raise ValueError(f'Invalid extent shape `{extent.shape}`')
         if not np.isfinite(extent).all():
-            raise ValueError('Invalid extent value `{}`'.format(extent))
+            raise ValueError(f'Invalid extent value `{extent}`')
         if extent[0] == extent[1] or extent[2] == extent[3]:
             raise ValueError('Empty extent')
 
@@ -246,7 +245,7 @@ class Footprint(TileMixin, IntersectionMixin, MoveMixin):
         elif scale.shape == (1,):
             scale = np.asarray([scale[0], -scale[0]], dtype='float64')
         elif scale.shape != (2,):
-            raise ValueError('scale has shape {} instead of (2,)'.format(scale.shape))
+            raise ValueError(f'scale has shape {scale.shape} instead of (2,)')
         if (scale == 0).any():
             raise ValueError('scale should be greater than 0')
 
@@ -500,7 +499,7 @@ class Footprint(TileMixin, IntersectionMixin, MoveMixin):
             elif resolution.shape == (1,):
                 resolution = np.asarray([resolution[0], -resolution[0]], dtype='float64')
             elif resolution.shape != (2,):
-                raise ValueError('resolution has shape {}'.format(resolution.shape))
+                raise ValueError(f'resolution has shape {resolution.shape}')
             if (resolution == 0).any():
                 raise ValueError('resolution should be different than zero')
 
@@ -520,7 +519,7 @@ class Footprint(TileMixin, IntersectionMixin, MoveMixin):
         else:
             alignment = np.asarray(alignment, dtype='float64')
             if alignment.shape != (2,):
-                raise ValueError('alignment has shape {}'.format(alignment.shape))
+                raise ValueError(f'alignment has shape {alignment.shape}')
 
         # Retrieve homogeneous
         homogeneous = bool(kwargs.pop('homogeneous', False))
@@ -528,7 +527,7 @@ class Footprint(TileMixin, IntersectionMixin, MoveMixin):
             for fp in footprints:
                 if not self.same_grid(fp):
                     raise ValueError(
-                        '{} does not lie on the same grid as self: {}'.format(fp, self)
+                        f'{fp} does not lie on the same grid as self: {self}'
                     )
 
         if kwargs:
@@ -1615,7 +1614,7 @@ class Footprint(TileMixin, IntersectionMixin, MoveMixin):
         """
         # Step 1: Parameter checking ************************************************************ **
         if arr.shape != tuple(self.shape):
-            raise ValueError('Incompatible shape between array:%s and self:%s' % (
+            raise ValueError('Incompatible shape between array:{} and self:{}'.format(
                 arr.shape, self.shape
             )) # pragma: no cover
 
@@ -1776,7 +1775,7 @@ class Footprint(TileMixin, IntersectionMixin, MoveMixin):
             target_ds, [1], rast_mem_lyr, options=options
         )
         if not success:
-            raise ValueError('Could not rasterize (gdal error: `{}`)'.format(payload[1]))
+            raise ValueError(f'Could not rasterize (gdal error: `{payload[1]}`)')
         arr = target_ds.GetRasterBand(1).ReadAsArray()
         return arr.astype(dtype, copy=False)
 
@@ -1814,7 +1813,7 @@ class Footprint(TileMixin, IntersectionMixin, MoveMixin):
 
         """
         if mask.shape != tuple(self.shape):
-            raise ValueError('Mask shape%s incompatible with self shape%s' % (
+            raise ValueError('Mask shape{} incompatible with self shape{}'.format(
                 mask.shape, tuple(self.shape)
             )) # pragma: no cover
         mask = mask.astype('uint8', copy=False).clip(0, 1)
@@ -1840,7 +1839,7 @@ class Footprint(TileMixin, IntersectionMixin, MoveMixin):
             iPixValField=0,
         )
         if not success:
-            raise ValueError('Could not polygonize (gdal error: `{}`)'.format(payload[1]))
+            raise ValueError(f'Could not polygonize (gdal error: `{payload[1]}`)')
         del source_ds
 
         def _polygon_iterator():
@@ -1929,7 +1928,7 @@ class Footprint(TileMixin, IntersectionMixin, MoveMixin):
             target_ds, [1], rast_mem_lyr, options=options
         )
         if not success:
-            raise ValueError('Could not rasterize (gdal error: `{}`)'.format(payload[1]))
+            raise ValueError(f'Could not rasterize (gdal error: `{payload[1]}`)')
         arr = target_ds.GetRasterBand(1).ReadAsArray()
         return arr.astype(dtype, copy=False)
 
@@ -2014,11 +2013,11 @@ class Footprint(TileMixin, IntersectionMixin, MoveMixin):
                 overlapy, size[1]
             ))
         if boundary_effect not in self._TILE_BOUNDARY_EFFECTS:
-            raise ValueError('boundary_effect(%s) should be one of %s' % (
+            raise ValueError('boundary_effect({}) should be one of {}'.format(
                 boundary_effect, self._TILE_BOUNDARY_EFFECTS
             ))
         if boundary_effect_locus not in self._TILE_BOUNDARY_EFFECT_LOCI:
-            raise ValueError('boundary_effect_locus(%s) should be one of %s' % (
+            raise ValueError('boundary_effect_locus({}) should be one of {}'.format(
                 boundary_effect_locus, self._TILE_BOUNDARY_EFFECT_LOCI
             ))
         return self._tile_unsafe(size, overlapx, overlapy, boundary_effect, boundary_effect_locus)
@@ -2090,11 +2089,11 @@ class Footprint(TileMixin, IntersectionMixin, MoveMixin):
         if overlapy < 0:
             raise ValueError('overlapy(%s) should satisfy overlapy >= 0' % overlapy)
         if boundary_effect not in self._TILE_BOUNDARY_EFFECTS:
-            raise ValueError('boundary_effect(%s) should be one of %s' % (
+            raise ValueError('boundary_effect({}) should be one of {}'.format(
                 boundary_effect, self._TILE_BOUNDARY_EFFECTS
             ))
         if boundary_effect_locus not in self._TILE_BOUNDARY_EFFECT_LOCI:
-            raise ValueError('boundary_effect_locus(%s) should be one of %s' % (
+            raise ValueError('boundary_effect_locus({}) should be one of {}'.format(
                 boundary_effect_locus, self._TILE_BOUNDARY_EFFECT_LOCI
             ))
 
@@ -2251,11 +2250,11 @@ class Footprint(TileMixin, IntersectionMixin, MoveMixin):
             )
 
         if boundary_effect not in self._TILE_OCCURRENCE_BOUNDARY_EFFECTS:
-            raise ValueError('boundary_effect(%s) should be one of %s' % (
+            raise ValueError('boundary_effect({}) should be one of {}'.format(
                 boundary_effect, self._TILE_OCCURRENCE_BOUNDARY_EFFECTS
             ))
         if boundary_effect_locus not in self._TILE_BOUNDARY_EFFECT_LOCI:
-            raise ValueError('boundary_effect_locus(%s) should be one of %s' % (
+            raise ValueError('boundary_effect_locus({}) should be one of {}'.format(
                 boundary_effect_locus, self._TILE_BOUNDARY_EFFECT_LOCI
             ))
 
@@ -2535,7 +2534,7 @@ class Footprint(TileMixin, IntersectionMixin, MoveMixin):
                 *np.flipud(rsize_inner),
                 *np.flipud(kernel_size),
             ))
-        rsize1 = 1 + np.floor((rsize_inner - (kernel_size - 1) - 1)) + output_padding
+        rsize1 = 1 + np.floor(rsize_inner - (kernel_size - 1) - 1) + output_padding
 
         # *********************************************************************** **
         aff = fp0._aff
@@ -2656,8 +2655,7 @@ def _line_iterator(obj):
             raise TypeError('Could not use type %s' % type(obj))
         else:
             for obj2 in tup:
-                for line in _line_iterator(obj2):
-                    yield line
+                yield from _line_iterator(obj2)
 
 def _poly_iterator(obj):
     if isinstance(obj, (sg.Polygon)):
@@ -2672,8 +2670,7 @@ def _poly_iterator(obj):
             raise TypeError('Could not use type %s' % type(obj))
         else:
             for obj2 in tup:
-                for poly in _poly_iterator(obj2):
-                    yield poly
+                yield from _poly_iterator(obj2)
 
 def _restore(gt, rsize):
     return Footprint(gt=gt, rsize=rsize)
@@ -2690,16 +2687,16 @@ def _parse_conv2d_params(*args, allow_neg_padding=True):
         if v.size == 1:
             v = np.asarray((v[0], v[0]))
         if v.size != 2: # pragma: no cover
-            raise ValueError('{} should have size 1 or 2'.format(k))
+            raise ValueError(f'{k} should have size 1 or 2')
         w = v.astype(int, copy=False)
         if np.any(v != w): # pragma: no cover
-            raise ValueError('{} should be of type int'.format(k))
+            raise ValueError(f'{k} should be of type int')
         if 'padding' not in k: # pragma: no cover
             if np.any(v < 1):
-                raise ValueError('{} should be greater or equal to 1'.format(k))
+                raise ValueError(f'{k} should be greater or equal to 1')
         if 'padding' in k and not allow_neg_padding: # pragma: no cover
             if np.any(v < 0):
-                raise ValueError('{} should be greater or equal to 0'.format(k))
+                raise ValueError(f'{k} should be greater or equal to 0')
 
         # Flip all params to work with `xy` and `rsize` (instead of `yx` and `shape`)
         v = np.flipud(v)

--- a/buzzard/_footprint_intersection.py
+++ b/buzzard/_footprint_intersection.py
@@ -1,6 +1,5 @@
 """>>> help(IntersectionMixin)"""
 
-from __future__ import division, print_function
 import functools
 import itertools
 
@@ -11,7 +10,7 @@ import shapely.geometry as sg
 from buzzard import _tools
 from buzzard._env import env
 
-class IntersectionMixin(object):
+class IntersectionMixin:
     """Private mixin for the Footprint class containing the `intersection` subroutines"""
 
     _INTERSECTION_RESOLUTIONS = {'self', 'highest', 'lowest'}
@@ -187,7 +186,6 @@ def _exterior_coords_iterator(geom):
         yield np.asarray(geom)
     elif isinstance(geom, sg.base.BaseMultipartGeometry):
         for part in geom:
-            for coords in _exterior_coords_iterator(part):
-                yield coords
+            yield from _exterior_coords_iterator(part)
     else:
         assert False

--- a/buzzard/_footprint_move.py
+++ b/buzzard/_footprint_move.py
@@ -3,7 +3,7 @@
 import numpy as np
 from buzzard._env import env
 
-class MoveMixin(object):
+class MoveMixin:
     """Private mixin for the Footprint class containing move subroutines"""
 
     def _snap_target_coordinates_before_move(self, tl1, tr1, br1):

--- a/buzzard/_footprint_tile.py
+++ b/buzzard/_footprint_tile.py
@@ -2,12 +2,12 @@
 
 import numpy as np
 
-class TileMixin(object):
+class TileMixin:
     """Private mixin for the Footprint class containing tiling subroutines"""
 
-    _TILE_BOUNDARY_EFFECTS = set(['extend', 'exclude', 'overlap', 'shrink', 'exception'])
-    _TILE_OCCURRENCE_BOUNDARY_EFFECTS = set(['extend', 'exception'])
-    _TILE_BOUNDARY_EFFECT_LOCI = set(['br', 'tr', 'tl', 'bl'])
+    _TILE_BOUNDARY_EFFECTS = {'extend', 'exclude', 'overlap', 'shrink', 'exception'}
+    _TILE_OCCURRENCE_BOUNDARY_EFFECTS = {'extend', 'exception'}
+    _TILE_BOUNDARY_EFFECT_LOCI = {'br', 'tr', 'tl', 'bl'}
 
     @staticmethod
     def _details_of_tiling_direction(tile_size, overlap_size, raster_size):
@@ -60,7 +60,7 @@ class TileMixin(object):
         gap, gen = self._details_of_tiling_direction(sizex, overlapx, self.rsizex)
         if gap < 0:
             raise ValueError(
-                'Cannot apply boundary_effect=overlap with a tile(%s) bigger than source(%s)' % (
+                'Cannot apply boundary_effect=overlap with a tile({}) bigger than source({})'.format(
                     sizex, self.rsizex
                 ))
         else:
@@ -73,7 +73,7 @@ class TileMixin(object):
         gap, gen = self._details_of_tiling_direction(sizey, overlapy, self.rsizey)
         if gap < 0:
             raise ValueError(
-                'Cannot apply boundary_effect=overlap with a tile(%s) bigger than source(%s)' % (
+                'Cannot apply boundary_effect=overlap with a tile({}) bigger than source({})'.format(
                     sizey, self.rsizey
                 ))
         else:

--- a/buzzard/_gdal_file_raster.py
+++ b/buzzard/_gdal_file_raster.py
@@ -23,7 +23,7 @@ class GDALFileRaster(APooledEmissaryRaster):
         back = BackGDALFileRaster(
             ds._back, allocator, open_options, mode,
         )
-        super(GDALFileRaster, self).__init__(ds=ds, back=back)
+        super().__init__(ds=ds, back=back)
 
 class BackGDALFileRaster(ABackPooledEmissaryRaster, ABackGDALRaster):
     """Implementation of GDALFileRaster"""
@@ -46,7 +46,7 @@ class BackGDALFileRaster(ABackPooledEmissaryRaster, ABackGDALRaster):
             else:
                 wkt_stored = sr
 
-        super(BackGDALFileRaster, self).__init__(
+        super().__init__(
             back_ds=back_ds,
             wkt_stored=wkt_stored,
             channels_schema=channels_schema,
@@ -68,7 +68,7 @@ class BackGDALFileRaster(ABackPooledEmissaryRaster, ABackGDALRaster):
             yield gdal_ds
 
     def delete(self):
-        super(BackGDALFileRaster, self).delete()
+        super().delete()
 
         success, payload = GDALErrorCatcher(gdal.GetDriverByName, none_is_error=True)(self.driver)
         if not success: # pragma: no cover

--- a/buzzard/_gdal_file_vector.py
+++ b/buzzard/_gdal_file_vector.py
@@ -23,7 +23,7 @@ class GDALFileVector(APooledEmissaryVector):
         back = BackGDALFileVector(
             ds._back, allocator, open_options, mode,
         )
-        super(GDALFileVector, self).__init__(ds=ds, back=back)
+        super().__init__(ds=ds, back=back)
 
 class BackGDALFileVector(ABackPooledEmissaryVector, ABackGDALVector):
     """Implementation of GDALFileVector"""
@@ -46,7 +46,7 @@ class BackGDALFileVector(ABackPooledEmissaryVector, ABackGDALVector):
             type = conv.str_of_wkbgeom(lyr.GetGeomType())
             layer = lyr.GetName()
 
-        super(BackGDALFileVector, self).__init__(
+        super().__init__(
             back_ds=back_ds,
             wkt_stored=wkt_stored,
             mode=mode,
@@ -113,7 +113,7 @@ class BackGDALFileVector(ABackPooledEmissaryVector, ABackGDALVector):
             yield gdal_objs
 
     def delete(self):
-        super(BackGDALFileVector, self).delete()
+        super().delete()
 
         success, payload = GDALErrorCatcher(gdal.GetDriverByName, none_is_error=True)(self.driver)
         if not success: # pragma: no cover

--- a/buzzard/_gdal_mem_raster.py
+++ b/buzzard/_gdal_mem_raster.py
@@ -19,7 +19,7 @@ class GDALMemRaster(AEmissaryRaster):
         back = BackGDALMemRaster(
             ds._back, fp, dtype, channel_count, channels_schema, open_options, sr,
         )
-        super(GDALMemRaster, self).__init__(ds=ds, back=back)
+        super().__init__(ds=ds, back=back)
 
 class BackGDALMemRaster(ABackEmissaryRaster, ABackGDALRaster):
     """Implementation of GDALMemRaster"""
@@ -45,7 +45,7 @@ class BackGDALMemRaster(ABackEmissaryRaster, ABackGDALRaster):
         else:
             wkt_stored = sr
 
-        super(BackGDALMemRaster, self).__init__(
+        super().__init__(
             back_ds=back_ds,
             wkt_stored=wkt_stored,
             channels_schema=channels_schema,
@@ -65,5 +65,5 @@ class BackGDALMemRaster(ABackEmissaryRaster, ABackGDALRaster):
         raise NotImplementedError('GDAL MEM driver does no allow deletion, use `close`')
 
     def close(self):
-        super(BackGDALMemRaster, self).close()
+        super().close()
         del self._gdal_ds

--- a/buzzard/_gdal_memory_vector.py
+++ b/buzzard/_gdal_memory_vector.py
@@ -18,7 +18,7 @@ class GDALMemoryVector(AEmissaryVector):
         back = BackGDALMemoryVector(
             ds._back, allocator, open_options,
         )
-        super(GDALMemoryVector, self).__init__(ds=ds, back=back)
+        super().__init__(ds=ds, back=back)
 
 class BackGDALMemoryVector(ABackEmissaryVector, ABackGDALVector):
     """Implementation of GDALMemoryVector"""
@@ -45,7 +45,7 @@ class BackGDALMemoryVector(ABackEmissaryVector, ABackGDALVector):
         type = conv.str_of_wkbgeom(lyr.GetGeomType())
         layer = lyr.GetName()
 
-        super(BackGDALMemoryVector, self).__init__(
+        super().__init__(
             back_ds=back_ds,
             wkt_stored=wkt_stored,
             mode='w',
@@ -71,6 +71,6 @@ class BackGDALMemoryVector(ABackEmissaryVector, ABackGDALVector):
         raise NotImplementedError('GDAL Memory driver does no allow deletion, use `close`')
 
     def close(self):
-        super(BackGDALMemoryVector, self).close()
+        super().close()
         del self._lyr
         del self._gdal_ds

--- a/buzzard/_numpy_raster.py
+++ b/buzzard/_numpy_raster.py
@@ -18,7 +18,7 @@ class NumpyRaster(AStoredRaster):
         back = BackNumpyRaster(
             ds._back, fp, array, channels_schema, wkt, mode
         )
-        super(NumpyRaster, self).__init__(ds=ds, back=back)
+        super().__init__(ds=ds, back=back)
 
     @property
     def array(self):
@@ -51,7 +51,7 @@ class BackNumpyRaster(ABackStoredRaster):
         if 'mask' not in channels_schema:
             channels_schema['mask'] = ['all_valid']
 
-        super(BackNumpyRaster, self).__init__(
+        super().__init__(
             back_ds=back_ds,
             wkt_stored=wkt,
             channels_schema=channels_schema,
@@ -137,7 +137,7 @@ class BackNumpyRaster(ABackStoredRaster):
             self._arr[..., i] = value
 
     def close(self):
-        super(BackNumpyRaster, self).close()
+        super().close()
         del self._arr
 
     @staticmethod


### PR DESCRIPTION
Used [pyupgrade](https://github.com/asottile/pyupgrade) to switch to Python 3.6+ syntax. This mainly consists of:
- Switching to f strings
- Change super() calls from `super(Parent, self)` to `super()`
- Drop subclassing from object 