### PR TITLE
Drop python2 libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,6 @@ The following table lists dependencies along with the minimum version, their sta
 | scikit-image     | >=0.14.0 | Yes       | [scikit-image](https://github.com/scikit-image/scikit-image/blob/master/LICENSE.txt) |                                                               |
 | chainmap         | >=1.0.2  | Yes       | [Python 2.7 license](https://bitbucket.org/jeunice/chainmap)                         | Only for python <3.2                                          |
 | pytest           | >=3.2.2  | No        | [MIT](https://docs.pytest.org/en/latest/license.html)                                | Only for tests                                                |
-| attrdict         | >=2.0.0  | No        | [MIT](https://github.com/bcj/AttrDict/blob/master/LICENSE.txt)                       | Only for tests                                                |
 
 ## How to install from terminal
 ### Anaconda and pip

--- a/README.md
+++ b/README.md
@@ -169,7 +169,6 @@ The following table lists dependencies along with the minimum version, their sta
 | sortedcontainers | >=1.5.9  | Yes       | [apache](https://github.com/grantjenks/python-sortedcontainers/blob/master/LICENSE)  |                                                               |
 | Rtree            | >=0.8.3  | Yes       | [MIT](https://github.com/Toblerity/rtree/blob/master/LICENSE.txt)                    |                                                               |
 | scikit-image     | >=0.14.0 | Yes       | [scikit-image](https://github.com/scikit-image/scikit-image/blob/master/LICENSE.txt) |                                                               |
-| chainmap         | >=1.0.2  | Yes       | [Python 2.7 license](https://bitbucket.org/jeunice/chainmap)                         | Only for python <3.2                                          |
 | pytest           | >=3.2.2  | No        | [MIT](https://docs.pytest.org/en/latest/license.html)                                | Only for tests                                                |
 
 ## How to install from terminal

--- a/buzzard/_env.py
+++ b/buzzard/_env.py
@@ -11,11 +11,7 @@ from osgeo import gdal, ogr, osr
 
 from buzzard._tools import conv, Singleton, deprecation_pool
 
-try:
-    from collections import ChainMap
-except:
-    # https://pypi.python.org/pypi/chainmap
-    from chainmap import ChainMap
+from collections import ChainMap
 
 # Sanitization ********************************************************************************** **
 _INDEX_DTYPES = list(conv.DTYPE_OF_NAME.keys())

--- a/buzzard/test/make_tile_set.py
+++ b/buzzard/test/make_tile_set.py
@@ -2,7 +2,6 @@
 
 from __future__ import division, print_function
 import itertools
-import attrdict
 
 import numpy as np
 
@@ -10,6 +9,10 @@ from buzzard import Footprint
 
 ALL_LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvw"
 
+class AttrDict(dict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__dict__ = self
 
 def make_tile_set(width, reso, tilevec=(1, -10)):
     """
@@ -124,5 +127,5 @@ def make_tile_set(width, reso, tilevec=(1, -10)):
             tl=tl, size=np.abs(diagvec), rsize=(diagvec / reso)
         )
         return fp
-    fps = attrdict.AttrDict({combo: _footprint_of_letters(combo) for combo in combos})
+    fps = AttrDict({combo: _footprint_of_letters(combo) for combo in combos})
     return fps

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -4,7 +4,6 @@ gdal==2.4.0
 coverage>=4.4.1
 codecov>=2.0.15
 pytest>=3.6.4
-attrdict>=2.0.0
 pytest-cov>=2.5.1
 pylint>=1.7.1
 torch>=1.2.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,6 @@
 coverage>=4.4.1
 codecov>=2.0.15
 pytest>=3.6.4
-attrdict>=2.0.0
 pytest-cov>=2.5.1
 pylint>=1.7.1
 Sphinx>=1.7.4

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,6 @@ if (3, 4) <= sys.version_info < (3, 5):
 else:
     reqs += ['scikit-image>=0.14.0', 'numpy>=1.15']
 
-if sys.version_info < (3, 2):
-    reqs += ['chainmap>=1.0.2']
-
 readme_path = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
     'README.md'


### PR DESCRIPTION
Since Python 2 is no longer supported, we could drop `attrdict` and `chainmap`. 