### PR TITLE
Remove unused imports

### DIFF
--- a/buzzard/_a_emissary.py
+++ b/buzzard/_a_emissary.py
@@ -70,7 +70,6 @@ class ABackEmissary(ABackStored):
         - May be overriden
         - Should always be called
         """
-        pass
 
 _DeleteRoutine = type('_DeleteRoutine', (_tools.CallOrContext,), {
     '__doc__': AEmissary.delete.__doc__,

--- a/buzzard/_a_emissary_raster.py
+++ b/buzzard/_a_emissary_raster.py
@@ -8,8 +8,6 @@ class AEmissaryRaster(AEmissary, AStoredRaster):
     ----------------
     None
     """
-    pass
 
 class ABackEmissaryRaster(ABackEmissary, ABackStoredRaster):
     """Implementation of AEmissaryRaster's specifications"""
-    pass

--- a/buzzard/_a_gdal_vector.py
+++ b/buzzard/_a_gdal_vector.py
@@ -9,7 +9,6 @@ import shapely.geometry as sg
 
 from buzzard._a_stored_vector import ABackStoredVector
 from buzzard._tools import conv, GDALErrorCatcher
-from buzzard._env import Env
 
 class ABackGDALVector(ABackStoredVector):
     """Abstract class defining the common implementation of all vector formats in OGR"""

--- a/buzzard/_a_pooled_emissary_raster.py
+++ b/buzzard/_a_pooled_emissary_raster.py
@@ -9,8 +9,6 @@ class APooledEmissaryRaster(APooledEmissary, AEmissaryRaster):
     ----------------
     None
     """
-    pass
 
 class ABackPooledEmissaryRaster(ABackPooledEmissary, ABackEmissaryRaster):
     """Implementation of APooledEmissaryRaster's specifications"""
-    pass

--- a/buzzard/_a_pooled_emissary_vector.py
+++ b/buzzard/_a_pooled_emissary_vector.py
@@ -9,8 +9,6 @@ class APooledEmissaryVector(APooledEmissary, AEmissaryVector):
     ----------------
     None
     """
-    pass
 
 class ABackPooledEmissaryVector(ABackPooledEmissary, ABackEmissaryVector):
     """Implementation of APooledEmissaryVector's specifications"""
-    pass

--- a/buzzard/_actors/cached/cache_supervisor.py
+++ b/buzzard/_actors/cached/cache_supervisor.py
@@ -1,6 +1,4 @@
 import enum
-import collections
-import itertools
 import logging
 import os
 

--- a/buzzard/_actors/cached/merger.py
+++ b/buzzard/_actors/cached/merger.py
@@ -1,5 +1,4 @@
 import functools
-import collections
 import multiprocessing as mp
 import multiprocessing.pool
 

--- a/buzzard/_actors/cached/query_infos.py
+++ b/buzzard/_actors/cached/query_infos.py
@@ -1,5 +1,5 @@
 from typing import (
-    Set, Dict, List, Sequence, Union, cast, NamedTuple, FrozenSet, Tuple, Mapping, AbstractSet
+    List, Sequence, Union, cast, NamedTuple, FrozenSet, Tuple, Mapping, AbstractSet
 )
 import collections
 import queue # Should be imported for `mypy`

--- a/buzzard/_actors/global_priorities_watcher.py
+++ b/buzzard/_actors/global_priorities_watcher.py
@@ -3,7 +3,6 @@ from typing import (
 )
 import uuid # For mypy
 
-import numpy as np
 import sortedcontainers
 
 from buzzard._footprint import Footprint # For mypy

--- a/buzzard/_actors/pool_waiting_room.py
+++ b/buzzard/_actors/pool_waiting_room.py
@@ -6,7 +6,6 @@ import logging
 import uuid # For mypy
 
 import sortedcontainers
-import numpy as np
 
 from buzzard._footprint import Footprint # For mypy
 from buzzard._actors.message import Msg

--- a/buzzard/_debug_observers_manager.py
+++ b/buzzard/_debug_observers_manager.py
@@ -1,5 +1,3 @@
-import collections
-
 class DebugObserversManager:
     """Delivers the callbacks to the observers provided by user in the `debug_observers` parameters.
     """

--- a/buzzard/_env.py
+++ b/buzzard/_env.py
@@ -6,8 +6,6 @@ import threading
 from collections import namedtuple
 import functools
 
-import cv2
-from osgeo import gdal, ogr, osr
 
 from buzzard._tools import conv, Singleton, deprecation_pool
 
@@ -165,7 +163,6 @@ class _CurrentEnv(Singleton):
     8.0
 
     """
-    pass
 
 for k in _OPTIONS.keys():
     setattr(_CurrentEnv, k, property(_ThreadMapStackGetter(k)))

--- a/buzzard/_tools/parameters.py
+++ b/buzzard/_tools/parameters.py
@@ -4,7 +4,6 @@ from collections.abc import Iterable
 import logging
 import functools
 
-import six
 import numpy as np
 
 from .helper_classes import Singleton

--- a/buzzard/test/test_dataset_activations.py
+++ b/buzzard/test/test_dataset_activations.py
@@ -1,18 +1,13 @@
 # pylint: disable=redefined-outer-name, unused-argument
 
 
-import uuid
-import os
-import sys
 import multiprocessing as mp
 import multiprocessing.pool
 
-import numpy as np
 import pytest
 import shapely.geometry as sg
 
 import buzzard as buzz
-from buzzard.test.tools import fpeq
 
 
 def test_vector():

--- a/buzzard/test/test_dataset_modes.py
+++ b/buzzard/test/test_dataset_modes.py
@@ -15,7 +15,7 @@ import pytest
 import shapely.ops
 
 import buzzard as buzz
-from buzzard.test.tools import fpeq, sreq, eq
+from buzzard.test.tools import fpeq, sreq
 from buzzard.test import make_tile_set
 from .tools import  get_srs_by_name
 

--- a/buzzard/test/test_dataset_registering.py
+++ b/buzzard/test/test_dataset_registering.py
@@ -3,17 +3,14 @@
 import os
 import tempfile
 import uuid
-import string
 import weakref
 import gc
 
 import numpy as np
 from osgeo import gdal
 import pytest
-import shapely.ops
 
 import buzzard as buzz
-from buzzard.test.tools import fpeq, sreq, eq
 from buzzard.test import make_tile_set
 from .tools import  get_srs_by_name
 

--- a/buzzard/test/test_footprint_move.py
+++ b/buzzard/test/test_footprint_move.py
@@ -1,6 +1,5 @@
 # pylint: disable=redefined-outer-name
 import numpy as np
-import pytest
 import buzzard as buzz
 
 S = 2 ** 14

--- a/buzzard/test/test_multi_ordered_dict.py
+++ b/buzzard/test/test_multi_ordered_dict.py
@@ -7,9 +7,7 @@ import weakref
 import gc
 import collections
 import uuid
-import itertools
 
-import pytest
 import numpy as np
 
 from buzzard._tools import MultiOrderedDict

--- a/buzzard/test/test_rastersource_getsetdata_basic.py
+++ b/buzzard/test/test_rastersource_getsetdata_basic.py
@@ -3,7 +3,6 @@
 # pylint: disable=redefined-outer-name
 
 import itertools
-import os
 import uuid
 import tempfile
 

--- a/buzzard/test/test_rastersource_opencreate.py
+++ b/buzzard/test/test_rastersource_opencreate.py
@@ -7,7 +7,6 @@
 
 # pylint: disable=redefined-outer-name
 
-import itertools
 import os
 import uuid
 import tempfile

--- a/buzzard/test/test_rastersource_resampling.py
+++ b/buzzard/test/test_rastersource_resampling.py
@@ -7,7 +7,6 @@ TODO: Unit test `remap` mixin on one side and `getsetdata_remap` elsewhere
 # pylint: disable=redefined-outer-name
 
 import itertools
-import os
 import uuid
 import tempfile
 

--- a/buzzard/test/test_vectorsource_opencreate.py
+++ b/buzzard/test/test_vectorsource_opencreate.py
@@ -12,15 +12,13 @@ import os
 import uuid
 import tempfile
 import operator
-from pprint import pprint
 
-import numpy as np
 import pytest
 from osgeo import gdal
 import shapely.geometry as sg
 
-from .tools import get_srs_by_name, eq
-from buzzard import Footprint, Dataset, srs
+from .tools import eq
+from buzzard import Dataset, srs
 
 # SR1 = get_srs_by_name('EPSG:2154')
 SR1 = dict(wkt="""GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.01745329251994328,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]]""")

--- a/doc/examples.py
+++ b/doc/examples.py
@@ -6,7 +6,6 @@ import boto3
 import buzzard as buzz
 from osgeo import gdal
 import shapely
-import scipy.ndimage
 import numpy as np
 import cv2
 

--- a/doc/notebook2/dsm_generation.py
+++ b/doc/notebook2/dsm_generation.py
@@ -1,6 +1,5 @@
 #inspired by github.com/buckinha/DiamondSquare
 
-import sys
 import uuid
 import random
 import itertools

--- a/doc/notebook2/example_tools.py
+++ b/doc/notebook2/example_tools.py
@@ -1,6 +1,5 @@
 import datetime
 import glob
-from pprint import pprint
 import time
 import urllib
 import urllib.parse
@@ -8,7 +7,6 @@ import urllib.request
 from concurrent.futures import ProcessPoolExecutor
 import http.client
 import os
-import uuid
 import gc
 
 import matplotlib.pyplot as plt
@@ -17,10 +15,7 @@ import xmltodict
 import buzzard as buzz
 import numpy as np
 from tqdm import tqdm
-import scipy.ndimage as ndi
-import skimage.morphology as skm
 
-from dsm_generation import generate_dsm as create_random_elevation_gtiff
 
 
 class Timer():
@@ -31,7 +26,6 @@ class Timer():
 
     def __exit__(self, *_):
         self._stop = datetime.datetime.now()
-        pass
 
     def __float__(self):
         dt = self._stop - self._start

--- a/doc/notebook2/part5.py
+++ b/doc/notebook2/part5.py
@@ -1,10 +1,8 @@
 import functools
-import os
 import multiprocessing as mp
 import multiprocessing.pool
 
 import buzzard as buzz
-import numpy as np
 import skimage.io
 
 import example_tools

--- a/scripts/pytest_parallel.py
+++ b/scripts/pytest_parallel.py
@@ -9,7 +9,6 @@ $ python buzzard/test/pytest_parallel.py -x .
 """
 
 import sys
-import subprocess
 from concurrent.futures import ThreadPoolExecutor
 import multiprocessing as mp
 import uuid


### PR DESCRIPTION
Used [autoflake](https://github.com/PyCQA/autoflake) to remove unused imports

Command used

```
autoflake --in-place --recursive --ignore-init-module-imports --remove-all-unused-imports .
```