### PR TITLE
Add pip to environment.yml

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -7,3 +7,4 @@ dependencies:
     - gdal>=2.1.3
     - shapely>= 1.5.16
     - Rtree>=0.8.3
+    - pip


### PR DESCRIPTION
Previously conda used to be shipped with pip. Now it needs to be explicitly added. Should be a step in fixing the docs