### PR TITLE
Fix readthedocs environment

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -7,3 +7,4 @@ dependencies:
     - gdal>=2.1.3
     - shapely>= 1.5.16
     - Rtree>=0.8.3
+    - pip

--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -1,7 +1,7 @@
 # Conda environment file used by our custom ReadTheDocs environment.
 name: buzzard
 dependencies:
-    - python>=3.6
+    - python=3.6
     - numpy>=1.13
     - scipy>=0.19.1
     - gdal>=2.1.3


### PR DESCRIPTION
Noticed that previously GDAL was installed from pypi leading to some issues. Hopefully this fixes the docs.