### PR TITLE
opencv-python → opencv-python-headless

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -11,6 +11,6 @@ dependencies:
     - Rtree>=0.8.3
     - pip
     - pip:
-      - opencv-python>=3.1.0
+      - opencv-python-headless>=3.1.0
       - pint>=0.8.1
       - sortedcontainers>=1.5.9

--- a/README.md
+++ b/README.md
@@ -156,19 +156,19 @@ https://buzzard.readthedocs.io/
 ## Dependencies
 The following table lists dependencies along with the minimum version, their status for the project and the related license.
 
-| Library          | Version  | Mandatory | License                                                                              | Comment                                                       |
-|------------------|----------|-----------|--------------------------------------------------------------------------------------|---------------------------------------------------------------|
-| gdal             | >=2.3.3  | Yes       | [MIT/X](https://gdal.org/license.html)                   | Hard to install. Will be included in `buzzard` wheels         |
-| opencv-python    | >=3.1.0  | Yes       | [3-clause BSD](http://opencv.org/license.html)                                       | Easy to install with `opencv-python` wheels. Will be optional |
-| shapely          | >=1.6.1  | Yes       | [3-clause BSD](https://github.com/Toblerity/Shapely/blob/master/LICENSE.txt)         |                                                               |
-| affine           | >=2.0.0  | Yes       | [3-clause BSD](https://github.com/sgillies/affine/blob/master/LICENSE.txt)           |                                                               |
-| numpy            | >=1.15.0 | Yes       | [numpy](https://numpy.org/doc/stable/license.html)                        |                                                               |
-| scipy            | >=0.19.1 | Yes       | [scipy](https://www.scipy.org/scipylib/license.html)                                 |                                                               |
-| pint             | >=0.8.1  | Yes       | [3-clause BSD](https://github.com/hgrecco/pint/blob/master/LICENSE)                  |                                                               ||                                                               |
-| sortedcontainers | >=1.5.9  | Yes       | [apache](https://github.com/grantjenks/python-sortedcontainers/blob/master/LICENSE)  |                                                               |
-| Rtree            | >=0.8.3  | Yes       | [MIT](https://github.com/Toblerity/rtree/blob/master/LICENSE.txt)                    |                                                               |
-| scikit-image     | >=0.14.0 | Yes       | [scikit-image](https://github.com/scikit-image/scikit-image/blob/master/LICENSE.txt) |                                                               |
-| pytest           | >=3.2.2  | No        | [MIT](https://docs.pytest.org/en/latest/license.html)                                | Only for tests                                                |
+| Library                | Version  | Mandatory | License                                                                              | Comment                                                       |
+|------------------------|----------|-----------|--------------------------------------------------------------------------------------|---------------------------------------------------------------|
+| gdal                   | >=2.3.3  | Yes       | [MIT/X](https://gdal.org/license.html)                                               | Hard to install. Will be included in `buzzard` wheels         |
+| opencv-python-headless | >=3.1.0  | Yes       | [3-clause BSD](http://opencv.org/license.html)                                       | Easy to install with `opencv-python-headless` wheels.         |
+| shapely                | >=1.6.1  | Yes       | [3-clause BSD](https://github.com/Toblerity/Shapely/blob/master/LICENSE.txt)         |                                                               |
+| affine                 | >=2.0.0  | Yes       | [3-clause BSD](https://github.com/sgillies/affine/blob/master/LICENSE.txt)           |                                                               |
+| numpy                  | >=1.15.0 | Yes       | [numpy](https://numpy.org/doc/stable/license.html)                                   |                                                               |
+| scipy                  | >=0.19.1 | Yes       | [scipy](https://www.scipy.org/scipylib/license.html)                                 |                                                               |
+| pint                   | >=0.8.1  | Yes       | [3-clause BSD](https://github.com/hgrecco/pint/blob/master/LICENSE)                  |                                                               |
+| sortedcontainers       | >=1.5.9  | Yes       | [apache](https://github.com/grantjenks/python-sortedcontainers/blob/master/LICENSE)  |                                                               |
+| Rtree                  | >=0.8.3  | Yes       | [MIT](https://github.com/Toblerity/rtree/blob/master/LICENSE.txt)                    |                                                               |
+| scikit-image           | >=0.14.0 | Yes       | [scikit-image](https://github.com/scikit-image/scikit-image/blob/master/LICENSE.txt) |                                                               |
+| pytest                 | >=3.2.2  | No        | [MIT](https://docs.pytest.org/en/latest/license.html)                                | Only for tests                                                |
 
 ## How to install from terminal
 ### Anaconda and pip

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 # Requirements
 # https://caremad.io/posts/2013/07/setup-vs-requirement/
 reqs = [
-    'opencv-python>=3.1.0',
+    'opencv-python-headless>=3.1.0',
     'gdal>=2.3.3',
     'shapely>=1.5.16',
     'affine>=2.0.0',


### PR DESCRIPTION
Installing the `opencv-python` wheel requires some graphical system dependencies such as `libgl1`.

The usage of OpenCV in `buzzard` is only headless, so [as recommended by the opencv-python project](https://github.com/opencv/opencv-python?tab=readme-ov-file#installation-and-usage), `opencv-python-headless` can be installed instead, and it does not require system dependencies to be installed.